### PR TITLE
zephyr: Remove duplicated API call

### DIFF
--- a/zephyr/include/arch/string.h
+++ b/zephyr/include/arch/string.h
@@ -19,29 +19,7 @@
 	memset(ptr, 0, size)
 
 
-void *memcpy(void *dest, const void *src, size_t length);
 void *memset(void *dest, int data, size_t count);
-
-static inline int memcpy_s(void *dest, size_t dest_size,
-				const void *src, size_t src_size)
-{
-	uint8_t *d = dest;
-	const uint8_t *s = src;
-
-	if (!dest || !src)
-		return -EINVAL;
-
-	if ((d + dest_size >= s && d + dest_size <= s + src_size) ||
-		(s + src_size >= d && s + src_size <= d + dest_size))
-		return -EINVAL;
-
-	if (src_size > dest_size)
-		return -EINVAL;
-
-	memcpy(dest, src, src_size);
-
-	return 0;
-}
 
 static inline int memset_s(void *dest, size_t dest_size,
 				int data, size_t count)

--- a/zephyr/include/platform/shim.h
+++ b/zephyr/include/platform/shim.h
@@ -61,18 +61,6 @@
 #define IPC_IDCIETC_DONE	(1 << 30)
 #define IPC_IDCIETC_MSG_MASK	0x3FFFFFFF
 
-
-
-static inline uint32_t shim_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(SHIM_BASE + reg));
-}
-
-static inline void shim_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(SHIM_BASE + reg)) = val;
-}
-
 static inline uint64_t shim_read64(uint32_t reg)
 {
 	return *((volatile uint64_t*)(SHIM_BASE + reg));
@@ -113,16 +101,6 @@ static inline uint32_t irq_read(uint32_t reg)
 static inline void irq_write(uint32_t reg, uint32_t val)
 {
 	*((volatile uint32_t*)(IRQ_BASE + reg)) = val;
-}
-
-static inline uint32_t ipc_read(uint32_t reg)
-{
-	return *((volatile uint32_t*)(IPC_HOST_BASE + reg));
-}
-
-static inline void ipc_write(uint32_t reg, uint32_t val)
-{
-	*((volatile uint32_t*)(IPC_HOST_BASE + reg)) = val;
 }
 
 static inline uint32_t idc_read(uint32_t reg, uint32_t core_id)

--- a/zephyr/include/sof/mailbox.h
+++ b/zephyr/include/sof/mailbox.h
@@ -46,17 +46,6 @@
 	MAILBOX_DEBUG_SIZE
 
 static inline
-void mailbox_dspbox_write(size_t offset, const void *src, size_t bytes)
-{
-}
-
-static inline
-void mailbox_dspbox_read(void *dest, size_t dest_size,
-			 size_t offset, size_t bytes)
-{
-}
-
-static inline
 void mailbox_hostbox_write(size_t offset, const void *src, size_t bytes)
 {
 }
@@ -69,11 +58,6 @@ void mailbox_hostbox_read(void *dest, size_t dest_size,
 
 static inline
 void mailbox_stream_write(size_t offset, const void *src, size_t bytes)
-{
-}
-
-static inline
-void mailbox_sw_reg_write(size_t offset, uint32_t src)
 {
 }
 


### PR DESCRIPTION
Some APIs are redefined in zephyr tree.

This patch fixes the compile error with https://github.com/thesofproject/zephyr/pull/4

Signed-off-by: Tedd Ho-Jeong An <tedd.an@intel.com>